### PR TITLE
Allow KiteUtils 0.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtmosphericModels"
 uuid = "c59cac55-771d-4f45-b14d-1c681463a295"
 authors = ["Uwe Fechner <fechner@aenarete.eu> and contributors"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -20,7 +20,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 FFTW = "1.9.0"
 HypergeometricFunctions = "0.3"
-KiteUtils = "0.11.12"
+KiteUtils = "0.11.12, 0.12"
 LinearAlgebra = "1.11, 1.12"
 MeshGrid = "1.0.3"
 NPZ = "0.4.3"


### PR DESCRIPTION
KiteUtils 0.12 is breaking only in `Logger` (positional counts became keywords)
and `SysState` (gained tether and winch type parameters). This package uses
neither, so this is a compat bound bump with no code changes.

Needed because the `KiteUtils = "0.11.12"` bound blocks SymbolicAWEModels and
V3Kite from resolving against 0.12.

See OpenSourceAWE/KiteUtils.jl#127 and aenarete/KitePodModels.jl#230.