### PR TITLE
Allow KiteUtils 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## AtmosphericModels v0.3.9 - 2026-08-12
+### Changed
+- Bump `KiteUtils` to 0.12.
+
 ## AtmosphericModels v0.3.8 - 2026-08-09
 ### Added
 - The `interpolate` keyword of `get_wind` is implemented. It used to be a documented keyword that

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtmosphericModels"
 uuid = "c59cac55-771d-4f45-b14d-1c681463a295"
 authors = ["Uwe Fechner <fechner@aenarete.eu> and contributors"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -20,7 +20,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 FFTW = "1.9.0"
 HypergeometricFunctions = "0.3"
-KiteUtils = "0.11.12"
+KiteUtils = "0.12"
 LinearAlgebra = "1.11, 1.12"
 MeshGrid = "1.0.3"
 NPZ = "0.4.3"


### PR DESCRIPTION
KiteUtils 0.12 is released. The compat bound here was the only thing keeping downstream packages (SymbolicAWEModels, V3Kite) from resolving against it.

- `KiteUtils = "0.11.12"` → `"0.12"`. Narrowed rather than widened: a union bound lets the resolver pick 0.11, and then a green CI says nothing about whether 0.12 works.
- Patch bump to 0.3.9 with a changelog entry, so the new bound can be registered.

No source change. Not tested locally on purpose — CI is the check here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)